### PR TITLE
only show nav when multiple items

### DIFF
--- a/packages/site/src/components/Navigation/TopNav.tsx
+++ b/packages/site/src/components/Navigation/TopNav.tsx
@@ -224,7 +224,7 @@ export function TopNav() {
           <HomeLink name={title} logo={logo} logoText={logo_text || logoText} />
         </div>
         <div className="flex-grow flex items-center w-auto">
-          <NavItems nav={nav} />
+          {(nav?.length ?? 0) > 1 && <NavItems nav={nav} />}
           <div className="block flex-grow"></div>
           <ThemeButton />
           <div className="block sm:hidden">


### PR DESCRIPTION
This removes some of the duplication on simpler sites where the logo text and project name usually mean duplicated text. For long titles, the site becomes unusable. 

This is probably better done via configuration in the build process itself -- this is a practical quick fix, that can be backend out